### PR TITLE
Add my desk's bluetooth mac prefix: f2:1a:9b

### DIFF
--- a/bluedesk/desks/default.py
+++ b/bluedesk/desks/default.py
@@ -56,7 +56,7 @@ class DefaultDesk:
             "99fa0020-338a-1024-8a49-009c0215f78a", 26) is False:
             return False
 
-        if self._addr[0:8] != "e4:d1:a7":
+        if self._addr[0:8] not in [ "e4:d1:a7", "f2:1a:9b"]:
             return False
 
         return True


### PR DESCRIPTION
Hey, I know this is deprecated, but I couldn't get node gyp to compile something with dbus, so I just wanted to make sure that it worked with my desk in quick way.  Knowing python made it easy to test and get it working.

I just got my desk today from IKEA, so it may be a new prefix?

This works great for me.